### PR TITLE
prefix deep queries

### DIFF
--- a/.changeset/rotten-coins-run.md
+++ b/.changeset/rotten-coins-run.md
@@ -1,0 +1,5 @@
+---
+'@aplinkosministerija/moleculer-accounts': patch
+---
+
+Prefix all left joined tables

--- a/packages/moleculer-accounts/src/mixins/deepQuery.ts
+++ b/packages/moleculer-accounts/src/mixins/deepQuery.ts
@@ -179,7 +179,7 @@ export function DeepQueryMixin() {
             this._joinField(params);
           }
 
-          console.log((q as any).toSQL());
+          // console.log((q as any).toSQL());
 
           return q;
         },

--- a/packages/moleculer-accounts/src/mixins/deepQuery.ts
+++ b/packages/moleculer-accounts/src/mixins/deepQuery.ts
@@ -92,6 +92,8 @@ export function DeepQueryMixin() {
       const knex = adapter.client;
       this.settings.tableName = adapter.opts.tableName;
 
+      const deepPrefix = 'deep_query'; // TODO: allow mixin config? or calculate from table column names
+
       adapter.createQuery = wrap(
         adapter.createQuery,
         (createQuery, params: any, opts: any = {}) => {
@@ -107,7 +109,7 @@ export function DeepQueryMixin() {
               const field = key.split('.')[0];
 
               if (this.settings.fields[field]?.deepQuery) {
-                const newKey = key.replace(/\./g, '_');
+                const newKey = deepPrefix + '_' + key.replace(/\./g, '_');
                 query[newKey] = value;
                 delete query[key];
 
@@ -126,7 +128,7 @@ export function DeepQueryMixin() {
               knex,
               q,
               tableName: snakeCase(this._getTableName()),
-              subTableName: snakeCase(fields[0]),
+              subTableName: deepPrefix + '_' + snakeCase(fields[0]),
               field: fields[0],
               fields,
               depth: 0,
@@ -176,6 +178,8 @@ export function DeepQueryMixin() {
 
             this._joinField(params);
           }
+
+          console.log((q as any).toSQL());
 
           return q;
         },

--- a/packages/moleculer-accounts/src/mixins/deepQuery.ts
+++ b/packages/moleculer-accounts/src/mixins/deepQuery.ts
@@ -179,8 +179,6 @@ export function DeepQueryMixin() {
             this._joinField(params);
           }
 
-          // console.log((q as any).toSQL());
-
           return q;
         },
       );


### PR DESCRIPTION
Prefix all "deep joins" with mixin name to avoid duplication of column names

```sql
with "deep_query_hunting_area" as (
  select 
    "id" as "deep_query_hunting_area_id", 
    "name" as "deep_query_hunting_area_name", 
    "display_name" as "deep_query_hunting_area_display_name", 
    "tenant_id" as "deep_query_hunting_area_tenant", 
    "mpv_id" as "deep_query_hunting_area_mpv_id", 
    "municipality_id" as "deep_query_hunting_area_municipality", 
    "created_by" as "deep_query_hunting_area_created_by", 
    "created_at" as "deep_query_hunting_area_created_at", 
    "updated_by" as "deep_query_hunting_area_updated_by", 
    "updated_at" as "deep_query_hunting_area_updated_at", 
    "deleted_by" as "deep_query_hunting_area_deleted_by", 
    "deleted_at" as "deep_query_hunting_area_deleted_at" 
  from 
    "hunting_areas" 
  where 
    "deleted_at" is null
) 
select 
  * 
from 
  "huntings" 
  left join "deep_query_hunting_area" on "huntings"."hunting_area_id" = "deep_query_hunting_area"."deep_query_hunting_area_id" 
where 
  ("deleted_at" is null) 
  and (
    "deep_query_hunting_area_municipality" in (?, ?)
  ) 
  and "deep_query_hunting_area_id" = ?
```